### PR TITLE
Fix documentation popup content.

### DIFF
--- a/lua/cmp_nvim_tags/init.lua
+++ b/lua/cmp_nvim_tags/init.lua
@@ -3,10 +3,10 @@ local util = require('vim.lsp.util')
 
 local source = {}
 
-local function buildDocumentation(completion_item)
+local function buildDocumentation(word)
   local document = {}
 
-  local tags = vim.fn.taglist(completion_item.word)
+  local tags = vim.fn.taglist(word)
   local doc = ''
   for i, tag in ipairs(tags) do
     if 10 < i then


### PR DESCRIPTION
Hi,

I noticed that when selecting a tag entry from completion, I get documentation with all the tag entries listed, instead of the thing I selected. I found a bug where word for taglist is referenced as table instead of string, because string is already passed from the documentation function. This PR fixes it.