### PR TITLE
fix: pcall should accept a function not a string

### DIFF
--- a/lua/cmp_nvim_tags/init.lua
+++ b/lua/cmp_nvim_tags/init.lua
@@ -6,7 +6,7 @@ local source = {}
 local function buildDocumentation(word)
   local document = {}
 
-  local list_tags_ok, tags = pcall("vim.fn.taglist", word)
+  local list_tags_ok, tags = pcall(vim.fn.taglist, word)
   if not list_tags_ok then
     return ""
   end


### PR DESCRIPTION
`BuildDocumentation` will always fail because pcall receives a string rather than a function