### PR TITLE
feat: add 'complete_defer' to option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ use {
   config = function ()
     require'cmp'.setup {
     sources = {
-      { name = 'tags' },
+      {
+        name = 'tags',
+        option = {
+          complete_defer = 100,
+        },
+      },
       -- more sources
     }
   }

--- a/lua/cmp_nvim_tags/init.lua
+++ b/lua/cmp_nvim_tags/init.lua
@@ -2,6 +2,9 @@ local cmp = require('cmp')
 local util = require('vim.lsp.util')
 
 local source = {}
+local default_options = {
+  complete_defer = 100,
+}
 
 local function buildDocumentation(word)
   local document = {}
@@ -67,6 +70,7 @@ end
 
 function source:complete(request, callback)
   local items = {}
+  local option = vim.tbl_deep_extend('keep', request.option or {}, default_options)
   vim.defer_fn(vim.schedule_wrap(function()
     local input = string.sub(request.context.cursor_before_line, request.offset)
     local _, tags = pcall(function()
@@ -90,7 +94,7 @@ function source:complete(request, callback)
       items = items,
       isIncomplete = true
     })
-  end), 100)
+  end), option.complete_defer)
 end
 
 function source:resolve(completion_item, callback)


### PR DESCRIPTION
In cmp-nvim-tags, there're some constants `10` in buildDocument, `100` in source.complete.
I add the `option` to cmp source, and provide custom ability to let user adjust these constants.