### PR TITLE
feat: add more options and optimizations

### DIFF
--- a/lua/cmp_nvim_tags/init.lua
+++ b/lua/cmp_nvim_tags/init.lua
@@ -9,7 +9,8 @@ local default_options = {
 local function buildDocumentation(word)
   local document = {}
 
-  local list_tags_ok, tags = pcall(vim.fn.taglist, word)
+  local exact_word = '^' .. word .. '$'
+  local list_tags_ok, tags = pcall(vim.fn.taglist, exact_word)
   if not list_tags_ok then
     return ""
   end

--- a/lua/cmp_nvim_tags/init.lua
+++ b/lua/cmp_nvim_tags/init.lua
@@ -18,7 +18,7 @@ local function buildDocumentation(word, bufname)
   end
   local list_tags_ok, tags = bufname and pcall(vim.fn.taglist, word, bufname)
     or pcall(vim.fn.taglist, word)
-  if not list_tags_ok then
+  if not list_tags_ok or type(tags) ~= "table" then
     return ""
   end
 

--- a/lua/cmp_nvim_tags/init.lua
+++ b/lua/cmp_nvim_tags/init.lua
@@ -78,7 +78,7 @@ end
 
 function source:complete(request, callback)
   local items = {}
-  global_option = vim.tbl_deep_extend('keep', request.option or {}, default_options)
+  global_options = vim.tbl_deep_extend('keep', request.option or {}, default_options)
   vim.defer_fn(vim.schedule_wrap(function()
     local input = string.sub(request.context.cursor_before_line, request.offset)
     local _, tags = pcall(function()
@@ -102,7 +102,7 @@ function source:complete(request, callback)
       items = items,
       isIncomplete = true
     })
-  end), global_option.complete_defer)
+  end), global_options.complete_defer)
 end
 
 function source:resolve(completion_item, callback)

--- a/lua/cmp_nvim_tags/init.lua
+++ b/lua/cmp_nvim_tags/init.lua
@@ -6,11 +6,11 @@ local default_options = {
   complete_defer = 100,
 }
 
-local function buildDocumentation(word)
+local function buildDocumentation(word, bufname)
   local document = {}
 
   local exact_word = '^' .. word .. '$'
-  local list_tags_ok, tags = pcall(vim.fn.taglist, exact_word)
+  local list_tags_ok, tags = pcall(vim.fn.taglist, exact_word, bufname)
   if not list_tags_ok then
     return ""
   end
@@ -101,7 +101,7 @@ end
 function source:resolve(completion_item, callback)
   completion_item.documentation = {
     kind = cmp.lsp.MarkupKind.Markdown,
-    value = buildDocumentation(completion_item.word)
+    value = buildDocumentation(completion_item.word, vim.api.nvim_buf_get_name(0))
   }
 
   callback(completion_item)


### PR DESCRIPTION
1. Feat: add more options: `max_items`, `exact_match`, `current_buffer_only`.
2. Perf: optimize the speed for completion, since I often feel laggy on my company's super big code base. There're two optimizations:
    - Use exact word match, add `'^' .. word .. '$'` to word, this will reduce the `taglist` function searching time. Please see discussion at: [#23330](https://github.com/neovim/neovim/issues/23330).
    - Add current buffer name to `taglist`, to prioritize the searching results.

Tested on my company's super big code base.