### PR TITLE
fix #15 and restore the default behavior before 3537690.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,16 @@ use {
       {
         name = 'tags',
         option = {
+          -- this is the default options, change them if you want.
           -- Delayed time after user input, in milliseconds.
           complete_defer = 100,
           -- Max items when searching `taglist`.
           max_items = 10,
           -- Use exact word match when searching `taglist`, for better searching
           -- performance.
-          exact_match = true,
+          exact_match = false,
           -- Prioritize searching result for current buffer.
-          current_buffer_only = true,
+          current_buffer_only = false,
         },
       },
       -- more sources

--- a/lua/cmp_nvim_tags/init.lua
+++ b/lua/cmp_nvim_tags/init.lua
@@ -5,8 +5,8 @@ local source = {}
 local default_options = {
   complete_defer = 100,
   max_items = 10,
-  exact_match = true,
-  current_buffer_only = true,
+  exact_match = false,
+  current_buffer_only = false,
 }
 local global_options = {}
 
@@ -16,8 +16,16 @@ local function buildDocumentation(word, bufname)
   if global_options.exact_match then
     word = '^' .. word .. '$'
   end
-  local list_tags_ok, tags = bufname and pcall(vim.fn.taglist, word, bufname)
-    or pcall(vim.fn.taglist, word)
+
+  local list_tags_ok
+  local tags
+
+  if bufname then
+    list_tags_ok, tags = pcall(vim.fn.taglist, word, bufname)
+  else
+    list_tags_ok, tags = pcall(vim.fn.taglist, word)
+  end
+
   if not list_tags_ok or type(tags) ~= "table" then
     return ""
   end


### PR DESCRIPTION
Multiple return values cannot be obtained via the “ternary” operator, an explicit if-else is necessary here.