### PR TITLE
add keyword_length config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ use {
           complete_defer = 100,
           -- Max items when searching `taglist`.
           max_items = 10,
+          -- The number of characters that need to be typed to trigger
+          -- auto-completion.
+          keyword_length = 3,
           -- Use exact word match when searching `taglist`, for better searching
           -- performance.
           exact_match = false,


### PR DESCRIPTION
With large tagfile(> 1GiB), complete when input less than 3 characters may cause badly laggy. And we don't need complete when input less than 3 characters in most circumstance.